### PR TITLE
Migrate from freegeoip

### DIFF
--- a/Exercise 1/Completed/Astronomy/Data/ILatLongService.cs
+++ b/Exercise 1/Completed/Astronomy/Data/ILatLongService.cs
@@ -1,0 +1,9 @@
+﻿using System.Threading.Tasks;
+
+namespace Astronomy
+{
+    public interface ILatLongService
+    {
+        Task<(double Latitude, double Longitude)> GetLatLong();
+    }
+}

--- a/Exercise 1/Completed/Astronomy/Data/LatLongService.cs
+++ b/Exercise 1/Completed/Astronomy/Data/LatLongService.cs
@@ -1,27 +1,14 @@
-﻿using Newtonsoft.Json;
-using System.Net.Http;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 
 namespace Astronomy
 {
-    public class LatLongService
+    public class FakeLatLongService : ILatLongService
     {
-        const string freeGeoIpServiceUrl = "http://freegeoip.net/json/";
-
+        static (double, double) RedmondCampusCoordinates = (47.641944, -122.127222);
         public async Task<(double Latitude, double Longitude)> GetLatLong()
         {
-            var json = await new HttpClient().GetStringAsync(freeGeoIpServiceUrl);
-
-            var data = JsonConvert.DeserializeObject<FreeGeoIpData>(json);
-
-            return (data.Latitude, data.Longitude);
-        }
-
-        class FreeGeoIpData
-        {
-            public string Ip { get; set; }
-            public double Latitude { get; set; }
-            public double Longitude { get; set; }
+            await Task.Delay(millisecondsDelay: 250);
+            return RedmondCampusCoordinates;
         }
     }
 }

--- a/Exercise 1/Completed/Astronomy/Pages/AboutPage.xaml
+++ b/Exercise 1/Completed/Astronomy/Pages/AboutPage.xaml
@@ -6,9 +6,8 @@
 
     <StackLayout Padding="10" Spacing="5">
         <Label Text="Version 1.0.0" />
-        <Label Text="Location Data provided by: https://freegeoip.net/" />
         <Label Text="Sunrise/Sunset data provided by: https://sunrise-sunset.org/api" />
         <Label Text="Icons from Font Awesome" />
     </StackLayout>
-    
+
 </ContentPage>

--- a/Exercise 1/Completed/Astronomy/Pages/AstronomicalBodiesPage.xaml.cs
+++ b/Exercise 1/Completed/Astronomy/Pages/AstronomicalBodiesPage.xaml.cs
@@ -8,6 +8,8 @@ namespace Astronomy.Pages
         {
             InitializeComponent();
 
+            NavigationPage.SetBackButtonTitle(this, "Back");
+
             btnEarth.Clicked += (s, e) => Navigation.PushAsync(new AstronomicalBodyPage(SolarSystemData.Earth));
             btnMoon.Clicked += (s, e) => Navigation.PushAsync(new AstronomicalBodyPage(SolarSystemData.Moon));
             btnSun.Clicked += (s, e) => Navigation.PushAsync(new AstronomicalBodyPage(SolarSystemData.Sun));

--- a/Exercise 1/Completed/Astronomy/Pages/SunrisePage.xaml.cs
+++ b/Exercise 1/Completed/Astronomy/Pages/SunrisePage.xaml.cs
@@ -6,9 +6,11 @@ namespace Astronomy.Pages
 {
     public partial class SunrisePage : ContentPage
     {
+        ILatLongService LatLongService { get; set; }
         public SunrisePage ()
         {
             InitializeComponent ();
+            LatLongService = new FakeLatLongService();
         }
 
         protected override async void OnAppearing()
@@ -20,7 +22,7 @@ namespace Astronomy.Pages
 
         async Task InitializeUI ()
         {
-            var latLongData = await new LatLongService().GetLatLong();
+            var latLongData = await LatLongService.GetLatLong();
             var sunData = await new SunriseService().GetSunriseSunsetTimes(latLongData.Latitude, latLongData.Longitude);
 
             var riseTime = sunData.Sunrise.ToLocalTime();

--- a/Exercise 1/Start/Astronomy/Data/ILatLongService.cs
+++ b/Exercise 1/Start/Astronomy/Data/ILatLongService.cs
@@ -1,0 +1,9 @@
+﻿using System.Threading.Tasks;
+
+namespace Astronomy
+{
+    public interface ILatLongService
+    {
+        Task<(double Latitude, double Longitude)> GetLatLong();
+    }
+}

--- a/Exercise 1/Start/Astronomy/Data/LatLongService.cs
+++ b/Exercise 1/Start/Astronomy/Data/LatLongService.cs
@@ -1,27 +1,14 @@
-﻿using Newtonsoft.Json;
-using System.Net.Http;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 
 namespace Astronomy
 {
-    public class LatLongService
+    public class FakeLatLongService : ILatLongService
     {
-        const string freeGeoIpServiceUrl = "http://freegeoip.net/json/";
-
+        static (double, double) RedmondCampusCoordinates = (47.641944, -122.127222);
         public async Task<(double Latitude, double Longitude)> GetLatLong()
         {
-            var json = await new HttpClient().GetStringAsync(freeGeoIpServiceUrl);
-
-            var data = JsonConvert.DeserializeObject<FreeGeoIpData>(json);
-
-            return (data.Latitude, data.Longitude);
-        }
-
-        class FreeGeoIpData
-        {
-            public string Ip { get; set; }
-            public double Latitude { get; set; }
-            public double Longitude { get; set; }
+            await Task.Delay(millisecondsDelay: 250);
+            return RedmondCampusCoordinates;
         }
     }
 }

--- a/Exercise 1/Start/Astronomy/Pages/AboutPage.xaml
+++ b/Exercise 1/Start/Astronomy/Pages/AboutPage.xaml
@@ -6,9 +6,8 @@
 
     <StackLayout Padding="10" Spacing="5">
         <Label Text="Version 1.0.0" />
-        <Label Text="Location Data provided by: https://freegeoip.net/" />
         <Label Text="Sunrise/Sunset data provided by: https://sunrise-sunset.org/api" />
         <Label Text="Icons from Font Awesome" />
     </StackLayout>
-    
+
 </ContentPage>

--- a/Exercise 1/Start/Astronomy/Pages/SunrisePage.xaml.cs
+++ b/Exercise 1/Start/Astronomy/Pages/SunrisePage.xaml.cs
@@ -6,9 +6,11 @@ namespace Astronomy.Pages
 {
     public partial class SunrisePage : ContentPage
     {
+        ILatLongService LatLongService { get; set; }
         public SunrisePage ()
         {
             InitializeComponent ();
+            LatLongService = new FakeLatLongService();
         }
 
         protected override async void OnAppearing()
@@ -20,7 +22,7 @@ namespace Astronomy.Pages
 
         async Task InitializeUI ()
         {
-            var latLongData = await new LatLongService().GetLatLong();
+            var latLongData = await LatLongService.GetLatLong();
             var sunData = await new SunriseService().GetSunriseSunsetTimes(latLongData.Latitude, latLongData.Longitude);
 
             var riseTime = sunData.Sunrise.ToLocalTime();

--- a/Exercise 2/Completed/Astronomy/Data/ILatLongService.cs
+++ b/Exercise 2/Completed/Astronomy/Data/ILatLongService.cs
@@ -1,0 +1,9 @@
+﻿using System.Threading.Tasks;
+
+namespace Astronomy
+{
+    public interface ILatLongService
+    {
+        Task<(double Latitude, double Longitude)> GetLatLong();
+    }
+}

--- a/Exercise 2/Completed/Astronomy/Data/LatLongService.cs
+++ b/Exercise 2/Completed/Astronomy/Data/LatLongService.cs
@@ -1,27 +1,14 @@
-﻿using Newtonsoft.Json;
-using System.Net.Http;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 
 namespace Astronomy
 {
-    public class LatLongService
+    public class FakeLatLongService : ILatLongService
     {
-        const string freeGeoIpServiceUrl = "http://freegeoip.net/json/";
-
+        static (double, double) RedmondCampusCoordinates = (47.641944, -122.127222);
         public async Task<(double Latitude, double Longitude)> GetLatLong()
         {
-            var json = await new HttpClient().GetStringAsync(freeGeoIpServiceUrl);
-
-            var data = JsonConvert.DeserializeObject<FreeGeoIpData>(json);
-
-            return (data.Latitude, data.Longitude);
-        }
-
-        class FreeGeoIpData
-        {
-            public string Ip { get; set; }
-            public double Latitude { get; set; }
-            public double Longitude { get; set; }
+            await Task.Delay(millisecondsDelay: 250);
+            return RedmondCampusCoordinates;
         }
     }
 }

--- a/Exercise 2/Completed/Astronomy/Pages/AboutPage.xaml
+++ b/Exercise 2/Completed/Astronomy/Pages/AboutPage.xaml
@@ -6,9 +6,8 @@
 
     <StackLayout Padding="10" Spacing="5">
         <Label Text="Version 1.0.0" />
-        <Label Text="Location Data provided by: https://freegeoip.net/" />
         <Label Text="Sunrise/Sunset data provided by: https://sunrise-sunset.org/api" />
         <Label Text="Icons from Font Awesome" />
     </StackLayout>
-    
+
 </ContentPage>

--- a/Exercise 2/Completed/Astronomy/Pages/SunrisePage.xaml.cs
+++ b/Exercise 2/Completed/Astronomy/Pages/SunrisePage.xaml.cs
@@ -6,9 +6,11 @@ namespace Astronomy.Pages
 {
     public partial class SunrisePage : ContentPage
     {
+        ILatLongService LatLongService { get; set; }
         public SunrisePage ()
         {
             InitializeComponent ();
+            LatLongService = new FakeLatLongService();
         }
 
         protected override async void OnAppearing()
@@ -20,7 +22,7 @@ namespace Astronomy.Pages
 
         async Task InitializeUI ()
         {
-            var latLongData = await new LatLongService().GetLatLong();
+            var latLongData = await LatLongService.GetLatLong();
             var sunData = await new SunriseService().GetSunriseSunsetTimes(latLongData.Latitude, latLongData.Longitude);
 
             var riseTime = sunData.Sunrise.ToLocalTime();

--- a/Exercise 3/Completed/Astronomy/Data/ILatLongService.cs
+++ b/Exercise 3/Completed/Astronomy/Data/ILatLongService.cs
@@ -1,0 +1,9 @@
+﻿using System.Threading.Tasks;
+
+namespace Astronomy
+{
+    public interface ILatLongService
+    {
+        Task<(double Latitude, double Longitude)> GetLatLong();
+    }
+}

--- a/Exercise 3/Completed/Astronomy/Data/LatLongService.cs
+++ b/Exercise 3/Completed/Astronomy/Data/LatLongService.cs
@@ -1,27 +1,14 @@
-﻿using Newtonsoft.Json;
-using System.Net.Http;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 
 namespace Astronomy
 {
-    public class LatLongService
+    public class FakeLatLongService : ILatLongService
     {
-        const string freeGeoIpServiceUrl = "http://freegeoip.net/json/";
-
+        static (double, double) RedmondCampusCoordinates = (47.641944, -122.127222);
         public async Task<(double Latitude, double Longitude)> GetLatLong()
         {
-            var json = await new HttpClient().GetStringAsync(freeGeoIpServiceUrl);
-
-            var data = JsonConvert.DeserializeObject<FreeGeoIpData>(json);
-
-            return (data.Latitude, data.Longitude);
-        }
-
-        class FreeGeoIpData
-        {
-            public string Ip { get; set; }
-            public double Latitude { get; set; }
-            public double Longitude { get; set; }
+            await Task.Delay(millisecondsDelay: 250);
+            return RedmondCampusCoordinates;
         }
     }
 }

--- a/Exercise 3/Completed/Astronomy/Pages/AboutPage.xaml
+++ b/Exercise 3/Completed/Astronomy/Pages/AboutPage.xaml
@@ -6,9 +6,8 @@
 
     <StackLayout Padding="10" Spacing="5">
         <Label Text="Version 1.0.0" />
-        <Label Text="Location Data provided by: https://freegeoip.net/" />
         <Label Text="Sunrise/Sunset data provided by: https://sunrise-sunset.org/api" />
         <Label Text="Icons from Font Awesome" />
     </StackLayout>
-    
+
 </ContentPage>

--- a/Exercise 3/Completed/Astronomy/Pages/SunrisePage.xaml.cs
+++ b/Exercise 3/Completed/Astronomy/Pages/SunrisePage.xaml.cs
@@ -6,9 +6,11 @@ namespace Astronomy.Pages
 {
     public partial class SunrisePage : ContentPage
     {
+        ILatLongService LatLongService { get; set; }
         public SunrisePage ()
         {
             InitializeComponent ();
+            LatLongService = new FakeLatLongService();
         }
 
         protected override async void OnAppearing()
@@ -20,7 +22,7 @@ namespace Astronomy.Pages
 
         async Task InitializeUI ()
         {
-            var latLongData = await new LatLongService().GetLatLong();
+            var latLongData = await LatLongService.GetLatLong();
             var sunData = await new SunriseService().GetSunriseSunsetTimes(latLongData.Latitude, latLongData.Longitude);
 
             var riseTime = sunData.Sunrise.ToLocalTime();

--- a/Exercise 4/Completed/Astronomy/Data/ILatLongService.cs
+++ b/Exercise 4/Completed/Astronomy/Data/ILatLongService.cs
@@ -1,0 +1,9 @@
+﻿using System.Threading.Tasks;
+
+namespace Astronomy
+{
+    public interface ILatLongService
+    {
+        Task<(double Latitude, double Longitude)> GetLatLong();
+    }
+}

--- a/Exercise 4/Completed/Astronomy/Data/LatLongService.cs
+++ b/Exercise 4/Completed/Astronomy/Data/LatLongService.cs
@@ -1,27 +1,14 @@
-﻿using Newtonsoft.Json;
-using System.Net.Http;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 
 namespace Astronomy
 {
-    public class LatLongService
+    public class FakeLatLongService : ILatLongService
     {
-        const string freeGeoIpServiceUrl = "http://freegeoip.net/json/";
-
+        static (double, double) RedmondCampusCoordinates = (47.641944, -122.127222);
         public async Task<(double Latitude, double Longitude)> GetLatLong()
         {
-            var json = await new HttpClient().GetStringAsync(freeGeoIpServiceUrl);
-
-            var data = JsonConvert.DeserializeObject<FreeGeoIpData>(json);
-
-            return (data.Latitude, data.Longitude);
-        }
-
-        class FreeGeoIpData
-        {
-            public string Ip { get; set; }
-            public double Latitude { get; set; }
-            public double Longitude { get; set; }
+            await Task.Delay(millisecondsDelay: 250);
+            return RedmondCampusCoordinates;
         }
     }
 }

--- a/Exercise 4/Completed/Astronomy/Pages/AboutPage.xaml
+++ b/Exercise 4/Completed/Astronomy/Pages/AboutPage.xaml
@@ -2,14 +2,13 @@
 <ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              x:Class="Astronomy.Pages.AboutPage"
-             xmlns:ios="clr-namespace:Xamarin.Forms.PlatformConfiguration.iOSSpecific;assembly=Xamarin.Forms.Core" 
-             ios:Page.UseSafeArea="true" 
+             xmlns:ios="clr-namespace:Xamarin.Forms.PlatformConfiguration.iOSSpecific;assembly=Xamarin.Forms.Core"
+             ios:Page.UseSafeArea="true"
              Title="About"
              Icon="question.png">
 
     <StackLayout Padding="10" Spacing="5">
         <Label Text="About Contoso Astronomy" FontSize="Large" />
-        <Label Text="Location Data provided by: https://freegeoip.net/" />
         <Label Text="Sunrise/Sunset data provided by: https://sunrise-sunset.org/api" />
         <Label Text="Icons from Font Awesome" />
     </StackLayout>

--- a/Exercise 4/Completed/Astronomy/Pages/SunrisePage.xaml.cs
+++ b/Exercise 4/Completed/Astronomy/Pages/SunrisePage.xaml.cs
@@ -6,9 +6,11 @@ namespace Astronomy.Pages
 {
     public partial class SunrisePage : ContentPage
     {
+        ILatLongService LatLongService { get; set; }
         public SunrisePage ()
         {
             InitializeComponent ();
+            LatLongService = new FakeLatLongService();
         }
 
         protected override async void OnAppearing()
@@ -20,7 +22,7 @@ namespace Astronomy.Pages
 
         async Task InitializeUI ()
         {
-            var latLongData = await new LatLongService().GetLatLong();
+            var latLongData = await LatLongService.GetLatLong();
             var sunData = await new SunriseService().GetSunriseSunsetTimes(latLongData.Latitude, latLongData.Longitude);
 
             var riseTime = sunData.Sunrise.ToLocalTime();

--- a/Exercise 4/Start/Astronomy/Data/ILatLongService.cs
+++ b/Exercise 4/Start/Astronomy/Data/ILatLongService.cs
@@ -1,0 +1,9 @@
+﻿using System.Threading.Tasks;
+
+namespace Astronomy
+{
+    public interface ILatLongService
+    {
+        Task<(double Latitude, double Longitude)> GetLatLong();
+    }
+}

--- a/Exercise 4/Start/Astronomy/Data/LatLongService.cs
+++ b/Exercise 4/Start/Astronomy/Data/LatLongService.cs
@@ -1,27 +1,14 @@
-﻿using Newtonsoft.Json;
-using System.Net.Http;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 
 namespace Astronomy
 {
-    public class LatLongService
+    public class FakeLatLongService : ILatLongService
     {
-        const string freeGeoIpServiceUrl = "http://freegeoip.net/json/";
-
+        static (double, double) RedmondCampusCoordinates = (47.641944, -122.127222);
         public async Task<(double Latitude, double Longitude)> GetLatLong()
         {
-            var json = await new HttpClient().GetStringAsync(freeGeoIpServiceUrl);
-
-            var data = JsonConvert.DeserializeObject<FreeGeoIpData>(json);
-
-            return (data.Latitude, data.Longitude);
-        }
-
-        class FreeGeoIpData
-        {
-            public string Ip { get; set; }
-            public double Latitude { get; set; }
-            public double Longitude { get; set; }
+            await Task.Delay(millisecondsDelay: 250);
+            return RedmondCampusCoordinates;
         }
     }
 }

--- a/Exercise 4/Start/Astronomy/Pages/AboutPage.xaml
+++ b/Exercise 4/Start/Astronomy/Pages/AboutPage.xaml
@@ -6,7 +6,6 @@
 
     <StackLayout Padding="10" Spacing="5">
         <Label Text="About Contoso Astronomy" FontSize="Large" />
-        <Label Text="Location Data provided by: https://freegeoip.net/" />
         <Label Text="Sunrise/Sunset data provided by: https://sunrise-sunset.org/api" />
         <Label Text="Icons from Font Awesome" />
     </StackLayout>

--- a/Exercise 4/Start/Astronomy/Pages/SunrisePage.xaml.cs
+++ b/Exercise 4/Start/Astronomy/Pages/SunrisePage.xaml.cs
@@ -6,9 +6,11 @@ namespace Astronomy.Pages
 {
     public partial class SunrisePage : ContentPage
     {
+        ILatLongService LatLongService { get; set; }
         public SunrisePage ()
         {
             InitializeComponent ();
+            LatLongService = new FakeLatLongService();
         }
 
         protected override async void OnAppearing()
@@ -20,7 +22,7 @@ namespace Astronomy.Pages
 
         async Task InitializeUI ()
         {
-            var latLongData = await new LatLongService().GetLatLong();
+            var latLongData = await LatLongService.GetLatLong();
             var sunData = await new SunriseService().GetSunriseSunsetTimes(latLongData.Latitude, latLongData.Longitude);
 
             var riseTime = sunData.Sunrise.ToLocalTime();


### PR DESCRIPTION
With freegeoip.net deprecating its service, we are moving to an interface system for geo-IP use that mocks out the location to always return the lat/lng of the Microsoft Redmond campus (per [Wikipedia](https://en.wikipedia.org/wiki/Microsoft_Redmond_campus)).

If folks want to implement their own provider, they just need to provide a method that hits their desired service and returns a ValueTuple of `(double, double)`.